### PR TITLE
Adds formatting for tooltip legend and refines chart options

### DIFF
--- a/src/calendar_visualization/CalendarHeatmap.js
+++ b/src/calendar_visualization/CalendarHeatmap.js
@@ -53,6 +53,8 @@ const CalendarHeatmap = (props) => {
 	return <CalendarChartWrapper className='vis' />
 }
 
+
+
 const drawCalendar = (props) => {
     var width = props.width,
     height = props.height,
@@ -222,6 +224,7 @@ const drawCalendar = (props) => {
         i === 0 ? range_labels.push("less") : i === props.color.length-1 ? range_labels.push("more") : range_labels.push("")
     }) : range_labels.push("less", "", "", "", "more")
 
+
     var legendLinear = legendColor()
     .shape(props.rounded ? 'circle' : 'rect')
     .shapeWidth(cellSize)
@@ -271,8 +274,14 @@ const drawCalendar = (props) => {
     function showTooltip(d) {
         //if showTooltip is passed a selection, then we know it's a legend swatch. Otherwise, it's a normal rect
         if(d instanceof d3.selection){
+            let formatted = d.text().split(" ").map((ele) => {
+                if(isNaN(Number(ele))){
+                    return ele
+                }
+                return props.formatting !== "" ? SSF.format(props.formatting, Number(ele)) : SSF.format(props.value_format, Number(ele))
+            })
             tooltip.style("opacity", .9);
-            tooltip.html(`<b>${d.text()}</b>`)
+            tooltip.html(`<b>${formatted.join(" ")}</b>`)
             .style("left", (d3.event.pageX - tooltip.style('width').slice(0,-2)) + "px")
             .style("top",  (d3.event.pageY - 40) + "px");
         } else {
@@ -280,7 +289,7 @@ const drawCalendar = (props) => {
             var text = d3.select(this).select("title").text();
             if(!text.split(':')[1] || d3.select(this).classed("hidden") || text.split(':')[1] == ' ∅') { return; }
             if(props.focus_tooltip) {
-                d3.selectAll(".day").style("opacity", 0.2);
+                d3.selectAll(".day").style("opacity", 0.4);
                 d3.select(this).style("opacity", 1.0);
             }
             tooltip.style("opacity", .9);

--- a/src/calendar_visualization/calendar_chart_container.js
+++ b/src/calendar_visualization/calendar_chart_container.js
@@ -27,7 +27,7 @@ const baseOptions = {
   },
   rounded: {
     type: "boolean",
-    label: "Rounded Cells?",
+    label: "Rounded Cells",
     default: false,
     section: "Style",
     order: 4
@@ -47,28 +47,28 @@ const baseOptions = {
   },
   label_year: {
     type: "boolean",
-    label: "Year Labels?",
+    label: "Year Labels",
     default: "true",
     section: "Style",
     order: 1
   },
   label_month: {
     type: "boolean",
-    label: "Month Labels?",
+    label: "Month Labels",
     default: "false",
     section: "Style",
     order: 2,
   },
   show_legend: {
     type: "boolean",
-    label: "Show Legend?",
+    label: "Show Legend",
     default: "true",
     section: "Style",
     order: 5
   },
   focus_tooltip: {
     type: "boolean",
-    label: "Focus Tooltip?",
+    label: "Focus on Hover",
     default: "true",
     section: "Style",
     order: 6
@@ -163,11 +163,14 @@ looker.plugins.visualizations.add({
       return;
     }
 
+
     const dim1  = queryResponse.fields.dimension_like[0].name;
     const dim1_label = queryResponse.fields.dimension_like[0].label_short;
 
     const meas1 = queryResponse.fields.measure_like[0].name;
     const meas1_label = queryResponse.fields.measure_like[0].label_short ? queryResponse.fields.measure_like[0].label_short : queryResponse.fields.measure_like[0].label;
+
+    const value_format = queryResponse.fields.measure_like[0].value_format != null ? queryResponse.fields.measure_like[0].value_format : ""
 
     let chunks = data.map(d => {
       return {
@@ -199,6 +202,7 @@ looker.plugins.visualizations.add({
          rows = {config.rows}
          measure_label = {meas1_label}
          dim_label = {dim1_label}
+         value_format = {value_format}
          label_year = {config.label_year}
          label_month = {config.label_month}
          label_week = {config.label_week}


### PR DESCRIPTION
Just dawned on me that we'd probably want label overrides as well - I was thinking just value overrides. I'll make another PR for that shortly. 

Also, got hacky with it -- the d3-svg-legend wants d3 formatting strings. Got a little messy converting from SSF to d3 formatting so just applied formatting in the showTooltip() function rather than .labelFormat() on the legendColor 